### PR TITLE
Update README to include stateless config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ app/config/security.yml
 firewalls:
     wsse_secured:
         pattern:   ^/api/.*
+        stateless: true
         wsse:
             realm: "Secured with WSSE" #identifies the set of resources to which the authentication information will apply (WWW-Authenticate)
             profile: "UsernameToken" #WSSE profile (WWW-Authenticate)


### PR DESCRIPTION
WSSE should be configured to be stateless otherwise a session may be started for users who auth this way