### PR TITLE
Add UserChecker to the authentication process

### DIFF
--- a/DependencyInjection/Security/Factory/Factory.php
+++ b/DependencyInjection/Security/Factory/Factory.php
@@ -49,12 +49,12 @@ class Factory implements SecurityFactoryInterface
 
         $container
             ->setDefinition($providerId, new DefinitionDecorator('escape_wsse_authentication.provider'))
-            ->replaceArgument(0, new Reference($userProviderId))
-            ->replaceArgument(1, $id)
-            ->replaceArgument(2, new Reference($this->encoderId))
-            ->replaceArgument(3, new Reference($this->nonceCacheId))
-            ->replaceArgument(4, $config['lifetime'])
-            ->replaceArgument(5, $config['date_format']);
+            ->replaceArgument(1, new Reference($userProviderId))
+            ->replaceArgument(2, $id)
+            ->replaceArgument(3, new Reference($this->encoderId))
+            ->replaceArgument(4, new Reference($this->nonceCacheId))
+            ->replaceArgument(5, $config['lifetime'])
+            ->replaceArgument(6, $config['date_format']);
 
         $entryPointId = $this->createEntryPoint($container, $id, $config, $defaultEntryPoint);
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     escape_wsse_authentication.provider:
         class:  %escape_wsse_authentication.provider.class%
-        arguments: [null, null, null, null, 300, '/^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/']
+        arguments: [@security.user_checker, null, null, null, null, 300, '/^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/']
 
     escape_wsse_authentication.listener:
         class:  %escape_wsse_authentication.listener.class%

--- a/Security/Core/Authentication/Provider/Provider.php
+++ b/Security/Core/Authentication/Provider/Provider.php
@@ -3,6 +3,7 @@
 namespace Escape\WSSEAuthenticationBundle\Security\Core\Authentication\Provider;
 
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -17,6 +18,7 @@ use Doctrine\Common\Cache\Cache;
 
 class Provider implements AuthenticationProviderInterface
 {
+    private $userChecker;
     private $userProvider;
     private $providerKey;
     private $encoder;
@@ -27,13 +29,16 @@ class Provider implements AuthenticationProviderInterface
     /**
      * Constructor.
      *
-     * @param UserProviderInterface    $userProvider              An UserProviderInterface instance
-     * @param PasswordEncoderInterface $encoder                   A PasswordEncoderInterface instance
-     * @param Cache                    $nonceCache                The nonce cache
-     * @param int                      $lifetime                  The lifetime
-     * @param string                   $dateFormat                The date format
+     * @param UserCheckerInterface     $userChecker  A UserChecketerInterface instance
+     * @param UserProviderInterface    $userProvider An UserProviderInterface instance
+     * @param string                   $providerKey  The provider key
+     * @param PasswordEncoderInterface $encoder      A PasswordEncoderInterface instance
+     * @param Cache                    $nonceCache   The nonce cache
+     * @param int                      $lifetime     The lifetime
+     * @param string                   $dateFormat   The date format
     */
     public function __construct(
+        UserCheckerInterface $userChecker,
         UserProviderInterface $userProvider,
         $providerKey,
         PasswordEncoderInterface $encoder,
@@ -47,6 +52,7 @@ class Provider implements AuthenticationProviderInterface
             throw new \InvalidArgumentException('$providerKey must not be empty.');
         }
 
+        $this->userChecker = $userChecker;
         $this->userProvider = $userProvider;
         $this->providerKey = $providerKey;
         $this->encoder = $encoder;
@@ -59,25 +65,25 @@ class Provider implements AuthenticationProviderInterface
     {
         $user = $this->userProvider->loadUserByUsername($token->getUsername());
 
-        if(
-            $user &&
-            $this->validateDigest(
+        if ($user) {
+            $this->userChecker->checkPreAuth($user);
+            if ($this->validateDigest(
                 $token->getCredentials(),
                 $token->getAttribute('nonce'),
                 $token->getAttribute('created'),
                 $this->getSecret($user),
                 $this->getSalt($user)
-           )
-        )
-        {
-            $authenticatedToken = new Token(
-                $user,
-                $token->getCredentials(),
-                $this->providerKey,
-                $user->getRoles()
-            );
+            )) {
+                $this->userChecker->checkPostAuth($user);
+                $authenticatedToken = new Token(
+                    $user,
+                    $token->getCredentials(),
+                    $this->providerKey,
+                    $user->getRoles()
+                );
 
-            return $authenticatedToken;
+                return $authenticatedToken;
+            }
         }
 
         throw new AuthenticationException('WSSE authentication failed.');

--- a/Tests/DependencyInjection/Security/Factory/FactoryTest.php
+++ b/Tests/DependencyInjection/Security/Factory/FactoryTest.php
@@ -103,12 +103,12 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $definition = $container->getDefinition('escape_wsse_authentication.provider.foo');
         $this->assertEquals(
             array(
-                'index_0' => new Reference('user_provider'),
-                'index_1' => 'foo',
-                'index_2' => new Reference($encoderId),
-                'index_3' => new Reference($nonceCacheId),
-                'index_4' => $lifetime,
-                'index_5' => $date_format
+                'index_1' => new Reference('user_provider'),
+                'index_2' => 'foo',
+                'index_3' => new Reference($encoderId),
+                'index_4' => new Reference($nonceCacheId),
+                'index_5' => $lifetime,
+                'index_6' => $date_format
             ),
             $definition->getArguments()
         );

--- a/Tests/Security/Core/Authentication/Provider/ProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/ProviderTest.php
@@ -23,6 +23,7 @@ class CustomProvider extends Provider
 
 class ProviderTest extends \PHPUnit_Framework_TestCase
 {
+    private $userChecker;
     private $userProvider;
     private $providerKey;
     private $encoder;
@@ -69,6 +70,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $this->userChecker = $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
         $this->userProvider = $this->getMock('Symfony\Component\Security\Core\User\UserProviderInterface');
         $this->providerKey = 'someproviderkey';
         $this->encoder = new MessageDigestPasswordEncoder('sha1', true, 1);
@@ -86,7 +88,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function supports($token, $expected)
     {
-        $provider = new Provider($this->userProvider, 'someproviderkey', $this->encoder, $this->nonceCache);
+        $provider = new Provider($this->userChecker, $this->userProvider, 'someproviderkey', $this->encoder, $this->nonceCache);
         $this->assertEquals($expected, $provider->supports($token));
     }
 
@@ -109,7 +111,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function validateDigestExpireTime()
     {
-        $provider = new CustomProvider($this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
+        $provider = new CustomProvider($this->userChecker, $this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
         $provider->validateDigest(null, null, date(DATE_ISO8601, (time() - 86400)), null, null);
     }
 
@@ -123,7 +125,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function validateDigestWithoutNonceDir($digest, $nonce, $created, $secret, $salt, $expected)
     {
-        $provider = new CustomProvider($this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
+        $provider = new CustomProvider($this->userChecker, $this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
         $result = $provider->validateDigest($digest, $nonce, $created, $secret, $salt);
         $this->assertEquals($expected, $result);
     }
@@ -138,7 +140,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function validateDigestWithNonceDir($digest, $nonce, $created, $secret, $salt, $expected)
     {
-        $provider = new CustomProvider($this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
+        $provider = new CustomProvider($this->userChecker, $this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
         $result = $provider->validateDigest($digest, $nonce, $created, $secret, $salt);
         $this->assertEquals($expected, $result);
 
@@ -166,7 +168,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function validateDigestWithNonceDirExpectedException($digest, $nonce, $created, $secret, $salt, $expected)
     {
-        $provider = new CustomProvider($this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
+        $provider = new CustomProvider($this->userChecker, $this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
 
         $this->nonceCache->save($nonce, time() - 123, 0);
 
@@ -223,7 +225,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function authenticateExpectedException()
     {
-        $provider = new CustomProvider($this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
+        $provider = new CustomProvider($this->userChecker, $this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
         $provider->authenticate(new Token($this->user, '', $this->providerKey));
     }
 
@@ -272,7 +274,7 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
         $token->setAttribute('nonce', base64_encode('somenonce'));
         $token->setAttribute('created', $time);
 
-        $provider = new CustomProvider($this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
+        $provider = new CustomProvider($this->userChecker, $this->userProvider, $this->providerKey, $this->encoder, $this->nonceCache);
         $result = $provider->authenticate($token);
 
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
This allows user provider classes to block users from authenticating.

I personally need this so I can activate/deactivate API users in my app. Supporting UserCheckerInterface makes this really easy.