### PR TITLE
Symfony 3.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ cache:
 
 before_script:
     # symfony/*
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.0' ]; then sed -i 's/~2\.3|3\.0\.\*/3.0.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.8' ]; then sed -i 's/~2\.3|3\.0\.\*/2.8.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '' ]; then sed -i 's/~2\.3|3\.0\.\*/2.7.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.3' ]; then sed -i 's/~2\.3|3\.0\.\*/2.3.*@dev/g' composer.json; composer update; fi"
+    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.0' ]; then sed -i 's/~2\.3|~3\.0/3.0.*@dev/g' composer.json; composer update; fi"
+    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.8' ]; then sed -i 's/~2\.3|~3\.0/2.8.*@dev/g' composer.json; composer update; fi"
+    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '' ]; then sed -i 's/~2\.3|~3\.0/2.7.*@dev/g' composer.json; composer update; fi"
+    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.3' ]; then sed -i 's/~2\.3|~3\.0/2.3.*@dev/g' composer.json; composer update; fi"
     - composer install
 
 matrix:
@@ -25,7 +25,7 @@ matrix:
     - php: 5.6
       env: SYMFONY_DEPS_VERSION=2.8
     - php: 5.6
-      env: SYMFONY_DEPS_VERSION=3
+      env: SYMFONY_DEPS_VERSION=3.0
     - php: 7.0
     - php: hhvm
     - php: hhvm-nightly

--- a/DependencyInjection/EscapeWSSEAuthenticationExtension.php
+++ b/DependencyInjection/EscapeWSSEAuthenticationExtension.php
@@ -2,6 +2,7 @@
 
 namespace Escape\WSSEAuthenticationBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -22,6 +23,16 @@ class EscapeWSSEAuthenticationExtension extends Extension
         $container->setParameter('escape_wsse_authentication.entry_point.class', $config['authentication_entry_point_class']);
         $container->setParameter('escape_wsse_authentication.encoder.class', $config['authentication_encoder_class']);
         $container->setParameter('escape_wsse_authentication.nonce_cache.class', $config['authentication_nonce_cache_class']);
+
+        // Use security.token_storage service for SF >= 2.6 and security.context for older versions.
+        // Revert to static service configuration when dropping support for SF 2.3.
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $tokenStorageReference = new Reference('security.token_storage');
+        } else {
+            $tokenStorageReference = new Reference('security.context');
+        }
+        $container->getDefinition('escape_wsse_authentication.listener')
+                  ->replaceArgument(0, $tokenStorageReference);
     }
 
     //https://github.com/symfony/symfony/issues/1768#issuecomment-1653074

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,7 +5,9 @@ services:
 
     escape_wsse_authentication.listener:
         class:  %escape_wsse_authentication.listener.class%
-        arguments: [@security.context, @security.authentication.manager]
+        arguments:
+          - null # replaced by @security.token_storage for SF >= 2.6, @security.context otherwise
+          - @security.authentication.manager
 
     escape_wsse_authentication.entry_point:
         class:  %escape_wsse_authentication.entry_point.class%

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,11 +7,11 @@ services:
         class:  %escape_wsse_authentication.listener.class%
         arguments:
           - null # replaced by @security.token_storage for SF >= 2.6, @security.context otherwise
-          - @security.authentication.manager
+          - '@security.authentication.manager'
 
     escape_wsse_authentication.entry_point:
         class:  %escape_wsse_authentication.entry_point.class%
-        arguments: [@logger, null, "UsernameToken"]
+        arguments: ['@logger', null, 'UsernameToken']
 
     escape_wsse_authentication.encoder:
         class:  %escape_wsse_authentication.encoder.class%

--- a/Security/Http/EntryPoint/EntryPoint.php
+++ b/Security/Http/EntryPoint/EntryPoint.php
@@ -6,7 +6,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 class EntryPoint implements AuthenticationEntryPointInterface
 {
@@ -31,7 +31,7 @@ class EntryPoint implements AuthenticationEntryPointInterface
         {
             if($ae instanceof AuthenticationException)
             {
-                $this->logger->warn($ae->getMessage());
+                $this->logger->warning($ae->getMessage());
             }
         }
 

--- a/Tests/Security/Http/EntryPoint/EntryPointTest.php
+++ b/Tests/Security/Http/EntryPoint/EntryPointTest.php
@@ -10,9 +10,9 @@ class EntryPointTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        if(!interface_exists('Symfony\Component\HttpKernel\Log\LoggerInterface'))
+        if(!interface_exists('Psr\Log\LoggerInterface'))
         {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
+            $this->markTestSkipped('Interface "Psr\Log\LoggerInterface" is not available');
         }
 
         if(!class_exists('Symfony\Component\HttpFoundation\Request'))
@@ -23,7 +23,7 @@ class EntryPointTest extends \PHPUnit_Framework_TestCase
 
     public function testStart()
     {
-        $logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $realm = 'TheRealm';
         $profile = 'TheProfile';
@@ -47,7 +47,7 @@ class EntryPointTest extends \PHPUnit_Framework_TestCase
 
     public function testStartWithNoException()
     {
-        $logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $realm = 'TheRealm';
         $profile = 'TheProfile';

--- a/Tests/Security/Http/Firewall/ListenerTest.php
+++ b/Tests/Security/Http/Firewall/ListenerTest.php
@@ -39,7 +39,15 @@ class ListenerTest extends \PHPUnit_Framework_TestCase
         $this->responseEvent = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $this->request = $this->getMockForAbstractClass('Symfony\Component\HttpFoundation\Request');
         $this->responseEvent->expects($this->once())->method('getRequest')->will($this->returnValue($this->request));
-        $this->securityContext = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            // TokenStorageInterface for SF >=2.7
+            $this->securityContext = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        } else {
+            // SecurityContextInterface for SF <2.6
+            $this->securityContext = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+
         $this->authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
         $this->authenticationEntryPoint = $this->getMock('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface');
     }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.9",
-        "symfony/framework-bundle": "~2.3|3.0.*",
-        "symfony/security-bundle": "~2.3|3.0.*",
+        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/security-bundle": "~2.3|~3.0",
         "doctrine/common": "~2.2"
     },
     "require-dev": {


### PR DESCRIPTION
This PR should achieve compatibility with Symfony 3.0 while keeping BC with 2.3. The token storage related changes are based on FriendsOfSymfony/FOSUserBundle/pull/1828.