### PR TITLE
Psr3 logging

### DIFF
--- a/Security/Core/Authentication/Provider/Provider.php
+++ b/Security/Core/Authentication/Provider/Provider.php
@@ -3,6 +3,7 @@
 namespace Escape\WSSEAuthenticationBundle\Security\Core\Authentication\Provider;
 
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
+use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -58,6 +59,12 @@ class Provider implements AuthenticationProviderInterface
     public function authenticate(TokenInterface $token)
     {
         $user = $this->userProvider->loadUserByUsername($token->getUsername());
+
+        if ($user instanceof AdvancedUserInterface) {
+            if (!$user->isEnabled()) {
+                throw new AuthenticationException('WSSE authentication failed.');
+            }
+        }
 
         if(
             !$token->hasAttribute('nonce') ||

--- a/Security/Core/Authentication/Provider/Provider.php
+++ b/Security/Core/Authentication/Provider/Provider.php
@@ -60,6 +60,14 @@ class Provider implements AuthenticationProviderInterface
         $user = $this->userProvider->loadUserByUsername($token->getUsername());
 
         if(
+            !$token->hasAttribute('nonce') ||
+            !$token->hasAttribute('created')
+          )
+        {
+            throw new AuthenticationException('WSSE authentication failed.');
+        }
+
+        if(
             $user &&
             $this->validateDigest(
                 $token->getCredentials(),

--- a/Security/Http/EntryPoint/EntryPoint.php
+++ b/Security/Http/EntryPoint/EntryPoint.php
@@ -31,7 +31,7 @@ class EntryPoint implements AuthenticationEntryPointInterface
         {
             if($ae instanceof AuthenticationException)
             {
-                $this->logger->warn($ae->getMessage());
+                $this->logger->warning($ae->getMessage());
             }
         }
 


### PR DESCRIPTION
In Symfony 3.0 and PSR-3, `LoggerInterface::warn()` will be removed. This PR fixes the issue.